### PR TITLE
fix: "NaN%" for avg-rating with no data

### DIFF
--- a/plugins/avg-rating/avg-rating.js
+++ b/plugins/avg-rating/avg-rating.js
@@ -40,7 +40,8 @@ async function addAvgRating() {
         ratingParent.appendChild(ratingTitle)
         const ratingValue = document.createElement("span")
         ratingValue.classList = "detail-item-value avg-rating"
-        ratingValue.innerText = `${rating}%`
+        // If the rating is not a number, return "N/A" instead of a percentage.
+        ratingValue.innerText = Number.isNaN(rating) ? "N/A" : `${rating}%`
         ratingParent.appendChild(ratingValue)
         // append to navbar
         document.querySelector(".detail-group").prepend(ratingParent)


### PR DESCRIPTION
I hope you don't mind me submitting a PR for this, as I really like the plugin and it seemed like a quick fix!

This fixes cases where there are no ratings to pull from, resulting in the average rating displaying as "NaN%".  This fix changes those cases to show "N/A" instead. See below for screenshots of the bug and the fix respectively. If you'd prefer it to read as something else, feel free to change it or I'm happy to amend it myself.

![bug](https://github.com/feederbox826/plugins/assets/154020147/b1f544a9-a59a-4c3c-b60c-ecdf60f543f9)
![fixed](https://github.com/feederbox826/plugins/assets/154020147/c1520802-b5b2-4fe8-a160-4d687d047715)

Thanks again for the cool plugin!