### PR TITLE
Fix back+forward marker navigation

### DIFF
--- a/plugins/vjs-shortcut/vjs-shortcut.js
+++ b/plugins/vjs-shortcut/vjs-shortcut.js
@@ -30,7 +30,7 @@ const navMarker = (next = true) => {
   const curTime = video.currentTime;
   const marker = next
     ? markers.find(marker => marker > curTime)
-    : markers.reverse().find(marker => marker < curTime-5)
+    : markers.toReversed().find(marker => marker < curTime-5)
   if (marker) video.currentTime = marker;
 }
 


### PR DESCRIPTION
`Array.prototype.reverse()` mutates the source array [in-place](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse), meaning forward marker navigation breaks after a back marker navigation.

`.toReversed()` is [fairly new](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed) - the legacy-safe alternative would be:

```js
[...markers].reverse()
```