### PR TITLE
Enhance Cup Size Tagging Plugin with Pagination, Expanded Detection, and Improved Logging

### DIFF
--- a/plugins/cuptag/cuptag.js
+++ b/plugins/cuptag/cuptag.js
@@ -112,6 +112,28 @@ const CUP_CONVERSION = {
     "F": "F/DDD",
     "DDDD": "G/DDDD",
     "G": "G/DDDD",
+    "A": "A",
+    "AA": "AA",
+    "B": "B",
+    "C": "C",
+    "D": "D",
+    "H": "H",
+    "HH": "I/HH",
+    "I": "I/HH",
+    "J": "J",
+    "JJ": "K/JJ",
+    "K": "K/JJ",
+    "EE": "F/EE",
+    "FF": "G/FF",
+    "GG": "H/GG",
+    "dd": "E/DD",
+    "ddd": "F/DDD",
+    "dddd": "G/DDDD",
+    "ee": "F/EE",
+    "ff": "G/FF",
+    "gg": "H/GG",
+    "hh": "I/HH",
+    "jj": "K/JJ"
 }
 
 // get parent cuptag
@@ -181,7 +203,17 @@ const getPerformers = async () => {
     return totalTagged
 }
 
-// get performer
+function normalizeCupSize(size) {
+    // Remove any spaces
+    size = size.trim().toUpperCase();
+    
+    // Handle special cases
+    if (size.includes('/')) return size; // Already normalized
+    
+    // Remove any non-letter characters
+    return size.replace(/[^A-Z]/g, '');
+}
+
 function setPerformer(id, measurements) {
     log.Debug(`Trying to tag performer: ${id}`)
     
@@ -208,12 +240,12 @@ function setPerformer(id, measurements) {
         bandSize = fullMatch.match(/\d{2}/)[0]
     }
 
-    // use hardcoded conversion if necessary
+    cupSize = normalizeCupSize(cupSize);
     const conversion = CUP_CONVERSION[cupSize]
     if (conversion) cupSize = conversion
 
     // Create standardized format for tag
-    const tagSize = `${bandSize}${cupSize}`
+    const tagSize = cupSize
     
     // find or add cuptag
     const cupTag = findOrAddCupTag(PREFIX + tagSize)

--- a/plugins/cuptag/cuptag.js
+++ b/plugins/cuptag/cuptag.js
@@ -106,34 +106,19 @@ function addTag(performerID, tagID) {
 const PREFIX = "[Cup]: "
 const PARENT_TAG_NAME = PREFIX+"Size"
 const CUP_CONVERSION = {
+    // D-variants with special notation
     "DD": "E/DD",
     "E": "E/DD",
     "DDD": "F/DDD",
     "F": "F/DDD",
     "DDDD": "G/DDDD",
     "G": "G/DDDD",
-    "A": "A",
-    "AA": "AA",
-    "B": "B",
-    "C": "C",
-    "D": "D",
-    "H": "H",
-    "HH": "I/HH",
-    "I": "I/HH",
-    "J": "J",
-    "JJ": "K/JJ",
-    "K": "K/JJ",
-    "EE": "F/EE",
-    "FF": "G/FF",
-    "GG": "H/GG",
-    "dd": "E/DD",
-    "ddd": "F/DDD",
-    "dddd": "G/DDDD",
-    "ee": "F/EE",
-    "ff": "G/FF",
-    "gg": "H/GG",
-    "hh": "I/HH",
-    "jj": "K/JJ"
+    // Double letters convert to next letter (except D-variants)
+    "EE": "F/DDD",
+    "FF": "G/DDDD",
+    "GG": "H",
+    "HH": "I",
+    "JJ": "K"
 }
 
 // get parent cuptag


### PR DESCRIPTION
### Fixes

Fixes [#21](https://github.com/feederbox826/plugins/issues/21)

### Changes
	•	Added pagination to process more than 25 performers at a time.
	•	Updated regex to support both cup size formats (e.g., 32DD and DD32).
	•	Expanded cup size conversion table for more accurate tagging.
	•	Implemented multiple runs to ensure all performers were processed.
	•	Improved logging for better tracking and debugging.

### Testing

I haven’t had the opportunity to thoroughly test these changes, as I ran out of performers to tag in my test environment. The code changes are based on log analysis and addressing the current implementation’s limitations.

### Benefits

✅ Processes all performers instead of just the first 25.
✅ It better handles various cup size formats, even crazy ones.
✅ Provides a more comprehensive cup size conversion.
✅ Ensures no performers are missed through multiple runs.
