### PR TITLE
Fix max speed increase bug in vjs-shortcuts

### DIFF
--- a/plugins/vjs-shortcut/vjs-shortcut.js
+++ b/plugins/vjs-shortcut/vjs-shortcut.js
@@ -46,8 +46,9 @@ const changePbRate = (increase = true) => {
   // if increase and is valid, increase
   // if decrease and is valid, decrease
   // otherwise do not change
-  const newRate =
-    increase && incrRate ? incrRate : decrRate ? decrRate : curRate;
+  const newRate = increase
+    ? (incrRate ?? curRate)
+    : (decrRate ?? curRate);
   player.playbackRate(newRate);
 };
 


### PR DESCRIPTION
In the case where the max playback rate (2.0x) is already selected, pressing the `>` key results in the playback rate being decreased to 1.75x, when it should be left at 2.0x.  This PR makes it behave as expected, resulting in no change in playback rate in this case.

Fixes #25 