### PR TITLE
vjs-shortcut: Remove reference to checkedMarkers

### DIFF
--- a/plugins/vjs-shortcut/vjs-shortcut.js
+++ b/plugins/vjs-shortcut/vjs-shortcut.js
@@ -74,8 +74,8 @@ function handleKey(evt) {
     evt.preventDefault();
   }
   // Ctrl + ], [ - Jump to next/previous marker
-  else if (key == "]" && !checkedMarkers && evt.ctrlKey) navMarker(true);
-  else if (key == "[" && !checkedMarkers && evt.ctrlKey) navMarker(false);
+  else if (key == "]" && evt.ctrlKey && markers.length) navMarker(true);
+  else if (key == "[" && evt.ctrlKey && markers.length) navMarker(false);
   // slow down playback rate
   else if (key == "<") changePbRate(false);
   // speed up playback rate


### PR DESCRIPTION
Removes lingering references to `checkedMarkers` and restores the old `markers.length` check.